### PR TITLE
remove image function

### DIFF
--- a/cmd/images.go
+++ b/cmd/images.go
@@ -10,6 +10,12 @@ import (
 // imagesCmd represents the images command
 var imagesCmd = &cobra.Command{
 	Use:   "images",
+	Short: "Show image options",
+	// Run: func(cmd *cobra.Command, args []string) {},
+}
+
+var imagesListCmd = &cobra.Command{
+	Use:   "ls",
 	Short: "List available images",
 	Run: func(cmd *cobra.Command, args []string) {
 		var token string
@@ -36,8 +42,43 @@ var imagesCmd = &cobra.Command{
 	},
 }
 
+var imagesRemoveCmd = &cobra.Command{
+	Use:   "rm",
+	Short: "Remove images",
+	Run: func(cmd *cobra.Command, args []string) {
+		var token string
+
+		proxy, _ := rootCmd.PersistentFlags().GetString("proxy")
+		utils.SetProxy(proxy)
+
+		providerFlag, _ := cmd.Flags().GetString("provider")
+		nameFlag, _ := cmd.Flags().GetString("name")
+		if providerFlag != "" {
+			viper.Set("provider", providerFlag)
+		}
+		provider := controller.GetProvider(viper.GetString("provider"))
+
+		switch provider {
+		case controller.PROVIDER_LINODE:
+			token = viper.GetString("linode.token")
+		case controller.PROVIDER_DIGITALOCEAN:
+			token = viper.GetString("digitalocean.token")
+		case controller.PROVIDER_VULTR:
+			token = viper.GetString("vultr.token")
+		}
+
+		controller.RemoveImages(token, provider, nameFlag)
+	},
+}
+
 func init() {
 	rootCmd.AddCommand(imagesCmd)
 
-	imagesCmd.Flags().StringP("provider", "p", "", "Service provider (Supported: linode, digitalocean, vultr)")
+	imagesCmd.AddCommand(imagesListCmd)
+	imagesListCmd.Flags().StringP("provider", "p", "", "Service provider (Supported: linode, digitalocean, vultr)")
+
+	imagesCmd.AddCommand(imagesRemoveCmd)
+	imagesRemoveCmd.Flags().StringP("provider", "p", "", "Service provider (Supported: linode, digitalocean, vultr)")
+	imagesRemoveCmd.Flags().StringP("name", "n", "pwn", "Fleet name.")
+
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -100,6 +100,14 @@ func ListImages(token string, provider Provider) {
 	}
 }
 
+func RemoveImages(token string, provider Provider, name string) {
+	c := GetProviderController(provider, token)
+	err := c.Service.RemoveImages(token, name)
+	if err != nil {
+		utils.Log.Fatal(err)
+	}
+}
+
 func CreateImage(token string, provider Provider, diskID string, label string) {
 	c := GetProviderController(provider, token)
 	diskIDInt, _ := strconv.Atoi(diskID)

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -39,6 +39,7 @@ type Provider interface {
 	GetBox(boxName, token string) (Box, error)
 	ListBoxes(token string)
 	ListImages(token string) error
+	RemoveImages(token string, name string) error
 	RunCommand(name, command string, port int, username, password, token string) error
 	CountFleet(fleetName string, boxes []Box) (count int)
 	DeleteFleet(name string, token string) error

--- a/pkg/services/digitalocean_service.go
+++ b/pkg/services/digitalocean_service.go
@@ -149,6 +149,11 @@ func (d DigitaloceanService) ListImages(token string) error {
 	return nil
 }
 
+// TODO
+func (l DigitaloceanService) RemoveImages(token string, name string) error {
+	return nil
+}
+
 func (d DigitaloceanService) DeleteFleet(name string, token string) error {
 	boxes, err := d.GetBoxes(token)
 	if err != nil {

--- a/pkg/services/linode_service.go
+++ b/pkg/services/linode_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"strconv"
@@ -141,6 +142,24 @@ func (l LinodeService) ListImages(token string) error {
 		fmt.Printf("%-18v %-48v %-6v %-29v %-15v\n", image.ID, image.Label, image.Size, image.Created, image.Vendor)
 	}
 	return nil
+}
+
+func (l LinodeService) RemoveImages(token string, name string) error {
+	images, err := l.getImages(token)
+	if err != nil {
+		return err
+	}
+	for _, image := range images {
+		if image.Label == name {
+			err := l.Client.DeleteImage(context.Background(), image.ID)
+			if err != nil {
+				return err
+			}
+			fmt.Println("Successfully removed:", name)
+		}
+		fmt.Printf("%-18v %-48v %-6v %-29v %-15v\n", image.ID, image.Label, image.Size, image.Created, image.Vendor)
+	}
+	return errors.New("Image not found")
 }
 
 func (l LinodeService) spawnBox(name string, image string, region string, size string, token string) error {

--- a/pkg/services/vultr_service.go
+++ b/pkg/services/vultr_service.go
@@ -159,6 +159,11 @@ func (v VultrService) ListImages(token string) error {
 	return nil
 }
 
+// TODO
+func (l VultrService) RemoveImages(token string, name string) error {
+	return nil
+}
+
 func (v VultrService) DeleteFleet(name string, token string) error {
 	boxes, err := v.GetBoxes(token)
 	if err != nil {


### PR DESCRIPTION
```
fleex images --help
```

```
Show image options

Usage:
  fleex images [command]

Available Commands:
  ls          List available images
  rm          Remove images
```

```
fleex images rm --help
```

```
Remove images

Usage:
  fleex images rm [flags]

Flags:
  -h, --help              help for rm
  -n, --name string       Fleet name. (default "pwn")
  -p, --provider string   Service provider (Supported: linode, digitalocean, vultr)
```